### PR TITLE
VD-3: Adds Deck Picking public methods.

### DIFF
--- a/App.vue
+++ b/App.vue
@@ -1,6 +1,5 @@
 <template>
     <div class="example">
-        <h1>hello</h1>
         <Mapbox
             :accessToken="mapboxToken"
             :settings="mapboxSettings"
@@ -8,18 +7,23 @@
             @created="setMap"
          />
         <DeckGl 
+            ref='deck'
             :map="map"
             :settings="deckglSettings"
             :class="['fill-wrapper']"
-            @created="setDeck"
         />
+        <div style="position:absolute;">
+            <button  @click="testSinglePick">Test Deck Single Pick object</button>
+            <button  @click="testMultiPick">Test Deck Multi Pick object</button>
+            <button  @click="testObjectsPick">Test Deck Objects Pick object</button>
+        </div>
     </div>
 </template>
 
 <script>
     import DeckGl from './deckgl'
     import Mapbox from './mapbox'
-    import MAPBOX_TOKEN from './env'
+    import MAPBOX_TOKEN from './env.js'
 
     const MAP_STYLES = {
         'satellite': 'mapbox://styles/mapbox/satellite-v9',
@@ -68,8 +72,14 @@
             setMap(map) {
                 this.map = map
             },
-            setDeck(deck) {
-                this.deck = deck
+            testSinglePick(){
+                console.log(this.$refs.deck.pickObject({x: 100, y:100, radius: 1}))
+            },
+            testMultiPick(){
+                console.log(this.$refs.deck.pickMultipleObjects({x: 100, y:100, radius: 1}))
+            },
+            testObjectsPick(){
+                console.log(this.$refs.deck.pickObjects({x: 100, y:100, radius: 1}))
             }
         }
     }

--- a/App.vue
+++ b/App.vue
@@ -73,13 +73,13 @@
                 this.map = map
             },
             testSinglePick(){
-                console.log(this.$refs.deck.pickObject({x: 100, y:100, radius: 1}))
+                console.log(this.$refs.deck.pickObject(100, 100, 0, null, false))
             },
             testMultiPick(){
-                console.log(this.$refs.deck.pickMultipleObjects({x: 100, y:100, radius: 1}))
+                console.log(this.$refs.deck.pickMultipleObjects(100, 100, 0, null, 10, false))
             },
             testObjectsPick(){
-                console.log(this.$refs.deck.pickObjects({x: 100, y:100, radius: 1}))
+                console.log(this.$refs.deck.pickObjects(100, 100, 1, 1, null))
             }
         }
     }

--- a/deckgl/DeckGl.vue
+++ b/deckgl/DeckGl.vue
@@ -30,14 +30,23 @@ export default {
     },
     methods: {
         moveMap({ viewState }) {
-                this.deck.setProps({ viewState: viewState })
-                this.map.jumpTo({
-                    center: [viewState.longitude, viewState.latitude],
-                    zoom: viewState.zoom,
-                    bearing: viewState.bearing,
-                    pitch: viewState.pitch,
-                })
-            }
+            this.deck.setProps({ viewState: viewState })
+            this.map.jumpTo({
+                center: [viewState.longitude, viewState.latitude],
+                zoom: viewState.zoom,
+                bearing: viewState.bearing,
+                pitch: viewState.pitch,
+            })
+        },
+        pickObject(opts) {
+            return this.deck.pickObject(opts);
+        },
+        pickMultipleObjects(opts) {
+            return this.deck.pickMultipleObjects(opts);
+        },
+        pickObjects(opts) {
+            return this.deck.pickObjects(opts);
+        }
     }
 }
 </script>

--- a/deckgl/DeckGl.vue
+++ b/deckgl/DeckGl.vue
@@ -38,14 +38,17 @@ export default {
                 pitch: viewState.pitch,
             })
         },
-        pickObject(opts) {
-            return this.deck.pickObject(opts);
+        //Get the closest pickable and visible object at the given screen coordinate.
+        pickObject(x, y, radius=0, layerIds=null, unproject3D=false) {
+            return this.deck.pickObject({x, y, radius, layerIds, unproject3D});
         },
-        pickMultipleObjects(opts) {
-            return this.deck.pickMultipleObjects(opts);
+        // Performs deep picking. Finds all close pickable and visible object at the given screen coordinate, even if those objects are occluded by other objects.
+        pickMultipleObjects(x, y, radius=0, layerIds=null, depth=10, unproject3D=false) {
+            return this.deck.pickMultipleObjects({x, y, radius, layerIds, depth, unproject3D});
         },
-        pickObjects(opts) {
-            return this.deck.pickObjects(opts);
+        //Get all pickable and visible objects within a bounding box.
+        pickObjects(x, y, width=1, height=1, layerIds=null) {
+            return this.deck.pickObjects({x, y, width, height, layerIds});
         }
     }
 }


### PR DESCRIPTION
This adds basic public methods on the Deck Component to call Picking the picking engine.

The abstraction here allows us to just add a Ref to the Deck Component, but keeps the actual Deck Object encapsulated within the component. 

I've also added a couple of test buttons to call those methods. These can be fleshed out more as we build a functional UI to play with and test new features. 

