### PR TITLE
VD-11: Expanding Testing

### DIFF
--- a/__mocks__/mapbox-gl.js
+++ b/__mocks__/mapbox-gl.js
@@ -1,0 +1,10 @@
+module.exports = {
+    // whatever properties and functions you need access to
+    GeolocateControl: jest.fn(),
+    Map: jest.fn(() => ({
+      addControl: jest.fn(),
+      on: jest.fn(),
+      remove: jest.fn(),
+    })),
+    NavigationControl: jest.fn(),
+  };

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -24,39 +24,10 @@
 <script>
     import DeckGl from '../src/components/deckgl'
     import Mapbox from '../src/components/mapbox'
+    import { MAPBOX_SETTINGS, DECKGL_SETTINGS} from '../src/components/utils/defaultSettings'
     import MAPBOX_TOKEN from '../env.js'
+    
 
-    const MAP_STYLES = {
-        'satellite': 'mapbox://styles/mapbox/satellite-v9',
-        'dark': 'mapbox://styles/mapbox/dark-v10'
-    }
-
-    const INITIAL_VIEW_STATE = {
-        latitude: 37.8,
-        longitude: -122.45,
-        zoom: 12,
-        bearing: 0,
-        pitch: 0
-    }
-    const MAPBOX_SETTINGS = {
-        accessToken: MAPBOX_TOKEN,
-        container: 'map',
-        width: '100%',
-        style: MAP_STYLES.dark,
-        interactive: false,
-        center: [INITIAL_VIEW_STATE.longitude, INITIAL_VIEW_STATE.latitude],
-        zoom: INITIAL_VIEW_STATE.zoom,
-        bearing: INITIAL_VIEW_STATE.bearing,
-        pitch: INITIAL_VIEW_STATE.pitch
-    }
-    const DECKGL_SETTINGS = {
-        canvas: "deck-canvas",
-        width: "100%",
-        height: "100%",
-        controller: true,
-        useDevicePixels: false,
-        viewState: INITIAL_VIEW_STATE,
-    }
 
     export default {
         components: { Mapbox, DeckGl },

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,6 @@
 module.exports = {
-  preset: '@vue/cli-plugin-unit-jest/presets/no-babel'
+  preset: '@vue/cli-plugin-unit-jest/presets/no-babel',
+  moduleNameMapper: {
+    '\\.(css|less)$': '<rootDir>/__mocks__/styleMock.js',
+  }
 }

--- a/src/components/utils/defaultSettings.js
+++ b/src/components/utils/defaultSettings.js
@@ -1,0 +1,41 @@
+
+/* eslint-disable no-unused-vars */
+
+export const MAP_STYLES = {
+    'satellite': 'mapbox://styles/mapbox/satellite-v9',
+    'dark': 'mapbox://styles/mapbox/dark-v10'
+}
+
+/* eslint-enable no-unused-vars */
+
+
+/* eslint-disable no-unused-vars */
+
+export const INITIAL_VIEW_STATE = {
+    latitude: 37.8,
+    longitude: -122.45,
+    zoom: 12,
+    bearing: 0,
+    pitch: 0
+}
+
+/* eslint-enable no-unused-vars */
+
+export const MAPBOX_SETTINGS = {
+    container: 'map',
+    width: '100%',
+    style: MAP_STYLES.dark,
+    interactive: false,
+    center: [INITIAL_VIEW_STATE.longitude, INITIAL_VIEW_STATE.latitude],
+    zoom: INITIAL_VIEW_STATE.zoom,
+    bearing: INITIAL_VIEW_STATE.bearing,
+    pitch: INITIAL_VIEW_STATE.pitch
+}
+export const DECKGL_SETTINGS = {
+    canvas: "deck-canvas",
+    width: "100%",
+    height: "100%",
+    controller: true,
+    useDevicePixels: false,
+    viewState: INITIAL_VIEW_STATE,
+}

--- a/src/components/utils/processChildren.js
+++ b/src/components/utils/processChildren.js
@@ -1,6 +1,10 @@
 export default (children) => {
     let map = null
 
+    if(children === undefined){
+        return map
+    }
+
     children.forEach(child => {
         // TODO: To add support for Slotted Layers, we will need to change this to a return type of {} with a map key and maybe a layers key which points to an Array.
         if(child.$options._componentTag === 'Mapbox'){

--- a/tests/unit/deckgl.spec.js
+++ b/tests/unit/deckgl.spec.js
@@ -1,9 +1,25 @@
 
 import { shallowMount } from "@vue/test-utils";
+
+import { DECKGL_SETTINGS } from "../../src/components/utils/defaultSettings.js"
 import { DeckGL } from "../../src/components/deckgl";
+
+let wrapper;
+
+beforeAll(() => {
+  wrapper = shallowMount(DeckGL, {
+    props:{
+      settings: DECKGL_SETTINGS
+    }
+  });
+});
+
+afterAll(()=>{
+  wrapper.destroy();
+});
 
 describe("DeckGL", () => {
     it("should mount", () => {
-      const deck = shallowMount(DeckGL);
+      expect(wrapper.isVueInstance).toBeTruthy()
     });
   });

--- a/tests/unit/mapbox.spec.js
+++ b/tests/unit/mapbox.spec.js
@@ -1,0 +1,26 @@
+
+import { shallowMount } from "@vue/test-utils";
+
+import { MAPBOX_SETTINGS } from "../../src/components/utils/defaultSettings.js"
+import { Mapbox } from "../../src/components/mapbox";
+
+let wrapper;
+
+beforeAll(() => {
+  wrapper = shallowMount(Mapbox, {
+    props:{
+      settings: MAPBOX_SETTINGS,
+      accessToken: ''
+    }
+  });
+});
+
+afterAll(()=>{
+  wrapper.destroy();
+});
+
+describe("Mapbox", () => {
+    it("should mount", () => {
+      expect(wrapper.isVueInstance).toBeTruthy()
+    });
+  });

--- a/tests/unit/utils/processChildren.spec.js
+++ b/tests/unit/utils/processChildren.spec.js
@@ -1,0 +1,44 @@
+import { shallowMount } from "@vue/test-utils";
+
+import processChildren from "../../../src/components/utils/processChildren.js"
+import { DECKGL_SETTINGS, MAPBOX_SETTINGS } from "../../../src/components/utils/defaultSettings.js"
+import { DeckGL } from "../../../src/components/deckgl";
+import { Mapbox } from "../../../src/components/mapbox";
+
+describe("processChildren", () => {
+    
+
+    it("should return a map with slotted component", () => {
+
+        const mapboxComponentWithoutProps = {
+            name: '',
+            render(h) {
+                return h('p')
+              }
+            } 
+        mapboxComponentWithoutProps.name = Mapbox.name
+
+        const deckComponent = shallowMount(DeckGL, {
+            props:{
+                settings: DECKGL_SETTINGS
+            },
+            slots:{
+                default: mapboxComponentWithoutProps
+            }
+        })
+        
+        const mapComponent = processChildren(deckComponent.$children)
+        expect(mapComponent).toBeDefined()
+    });
+
+    it("should not return a map with no slotted components", ()=>{
+        const deckComponent = shallowMount(DeckGL,{
+            props:{
+                settings: DECKGL_SETTINGS
+            }
+        })
+        
+        const mapComponent = processChildren(deckComponent.$children)
+        expect(mapComponent).toBeNull()
+    });
+  });


### PR DESCRIPTION
This upgrades testing suite to include Mock examples as we need to mock out specific third-party methods, functionality, etc.

It also includes initial testing for processChildren utils + Mapbox/DeckGL Components.

Moves all the default settings to a utils folder to be reused. 