### PR TITLE
VD-23

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -2,17 +2,30 @@
     <div class="example">
         <DeckGl 
             ref="deck"
+            :test="'BLAH'"
             :settings="deckglSettings"
             :class="['fill-wrapper']"
-            :controlMap="false"
+            :controlMap="true"
             :layers="layers"
-            :getTooltip="getTooltip"
+            :canvas="'deck-canvas'"
+            :width="'100%'"
+            :height="'100%'"
+            :controller="true"
+            :useDevicePixels="false"
+            :viewState="deckglSettings.viewState"
             >
-            <Mapbox
-            :accessToken="mapboxToken"
-            :settings="mapboxSettings"
-            :class="['fill-wrapper']"
-            />
+                <Mapbox
+                :class="['fill-wrapper']"
+                :accessToken="mapboxToken"
+                :map_style="mapboxSettings.style"
+                :container="'map'"
+                :width="'100%'"
+                :interactive="false"
+                :center="mapboxSettings.center"
+                :zoom="mapboxSettings.zoom"
+                :bearing="mapboxSettings.bearing"
+                :pitch="mapboxSettings.pitch"
+                />
         </DeckGl>
         <div style="position:absolute;">
             <button  @click="testSinglePick">Test Deck Single Pick object</button>
@@ -38,13 +51,8 @@
                 mapboxToken: MAPBOX_TOKEN,
                 mapboxSettings: MAPBOX_SETTINGS,
                 deckglSettings: DECKGL_SETTINGS,
-                layers:[],
-            }
-        },
-        mounted(){
-            this.layers.push(
-                new GeoJsonLayer({
-                        id: 'geojson',
+                layers:[ new GeoJsonLayer({
+                        id: 'mylayer',
                         data: DATA_URL,
                         opacity: 0.8,
                         stroked: false,
@@ -56,8 +64,8 @@
                         getFillColor: f => colorScale(f.properties.growth),
                         getLineColor: [255, 255, 255],
                         pickable: true,
-                        })
-                )
+                        })],
+            }
         },
         methods: {
            getTooltip,

--- a/src/components/deckgl/DeckGl.vue
+++ b/src/components/deckgl/DeckGl.vue
@@ -9,6 +9,7 @@
 import { Deck } from "@deck.gl/core"
 
 import processChildren from "../utils/processChildren.js"
+import {DECKGL_SETTINGS} from '../utils/defaultSettings.js'
 
 export default {
     name: 'deckgl',
@@ -29,7 +30,7 @@ export default {
         }        
     },
     mounted() {
-        this.deck = new Deck({ 
+        this.deck = new Deck({ ...DECKGL_SETTINGS,
         ...this.$attrs, 
         ...this.$props, 
         onViewStateChange: this.moveMap,

--- a/src/components/deckgl/DeckGl.vue
+++ b/src/components/deckgl/DeckGl.vue
@@ -1,5 +1,5 @@
 <template>
-    <div>
+    <div >
         <slot></slot>
         <canvas id="deck-canvas"></canvas>
     </div>
@@ -19,29 +19,20 @@ export default {
         }
     },
     props: {
-        settings: {
-            type: Object,
-            required: true
-        },
-        layers: {
-            type: Array
-        },
         controlMap: {
             type: Boolean,
             default: false
         },
-        getTooltip: {
-            type: Function,
+        layers: {
+            type: Array,
             required: false
-        }
-        
+        }        
     },
     mounted() {
-        
-        this.deck = new Deck({ ...this.settings, 
+        this.deck = new Deck({ 
+        ...this.$attrs, 
+        ...this.$props, 
         onViewStateChange: this.moveMap,
-        layers:this.layers,
-        getTooltip: ({object}) =>  this.getTooltip({object})
         })
 
         this.map = processChildren(this.$children)

--- a/src/components/mapbox/Mapbox.vue
+++ b/src/components/mapbox/Mapbox.vue
@@ -6,6 +6,7 @@
 <script>
     import mapboxgl from 'mapbox-gl'
     import 'mapbox-gl/dist/mapbox-gl.css'
+    import {MAPBOX_SETTINGS} from '../utils/defaultSettings.js'
 
     export default {
         name:'Mapbox',
@@ -21,12 +22,13 @@
             },
             map_style: {
                 type: String,
-                required: false
+                required: false,
+                default: MAPBOX_SETTINGS.style
             }
         },
         mounted() {
             mapboxgl.accessToken = this.accessToken
-            this.map = new mapboxgl.Map({...this.$attrs, style: this.map_style})
+            this.map = new mapboxgl.Map({...MAPBOX_SETTINGS, ...this.$attrs, style: this.map_style })
         },
         methods: {
             jumpTo(center, zoom, bearing, pitch){

--- a/src/components/mapbox/Mapbox.vue
+++ b/src/components/mapbox/Mapbox.vue
@@ -19,14 +19,14 @@
                 type: String,
                 required: true
             },
-            settings: {
-                type: Object,
-                required: true
+            map_style: {
+                type: String,
+                required: false
             }
         },
         mounted() {
             mapboxgl.accessToken = this.accessToken
-            this.map = new mapboxgl.Map(this.settings)
+            this.map = new mapboxgl.Map({...this.$attrs, style: this.map_style})
         },
         methods: {
             jumpTo(center, zoom, bearing, pitch){

--- a/tests/unit/deckgl.spec.js
+++ b/tests/unit/deckgl.spec.js
@@ -7,11 +7,12 @@ import { DeckGL } from "../../src/components/deckgl";
 let wrapper;
 
 beforeAll(() => {
-  wrapper = shallowMount(DeckGL, {
-    props:{
-      settings: DECKGL_SETTINGS
-    }
-  });
+  wrapper = shallowMount(DeckGL,{
+      attrs:{
+        canvas: null,
+    },
+  }
+    );
 });
 
 afterAll(()=>{

--- a/tests/unit/utils/processChildren.spec.js
+++ b/tests/unit/utils/processChildren.spec.js
@@ -1,7 +1,6 @@
 import { shallowMount } from "@vue/test-utils";
 
 import processChildren from "../../../src/components/utils/processChildren.js"
-import { DECKGL_SETTINGS, MAPBOX_SETTINGS } from "../../../src/components/utils/defaultSettings.js"
 import { DeckGL } from "../../../src/components/deckgl";
 import { Mapbox } from "../../../src/components/mapbox";
 
@@ -19,8 +18,8 @@ describe("processChildren", () => {
         mapboxComponentWithoutProps.name = Mapbox.name
 
         const deckComponent = shallowMount(DeckGL, {
-            props:{
-                settings: DECKGL_SETTINGS
+            attrs:{
+                canvas: null,
             },
             slots:{
                 default: mapboxComponentWithoutProps
@@ -33,10 +32,9 @@ describe("processChildren", () => {
 
     it("should not return a map with no slotted components", ()=>{
         const deckComponent = shallowMount(DeckGL,{
-            props:{
-                settings: DECKGL_SETTINGS
-            }
-        })
+        attrs:{
+            canvas: null,
+        },})
         
         const mapComponent = processChildren(deckComponent.$children)
         expect(mapComponent).toBeNull()


### PR DESCRIPTION
This PR moves the responsibility of applying DeckGL/Mapbox properties from a Settings object passed through component props to dynamically passing all attributes attached on the component to the respective DeckGL/MapBox constructors.

We do this by using the spread operator new Deckgl({...this.$attrs, ..this.$props). 

This has a few benefits: 

1. We can now avoid the trap of having to dynamically allocate a 1-to-1 relationship with the Deck/Mapbox APIs and avoid abstracting individual pieces out as props while also removing the need for a large settings object that we can't validate as easy.
2. The Vue API for binding to attributes and props is effectively the same :binding_name="value". If you have this defined as a prop it can be accessed via $props, if not, through $attrs (which allows us to do the destructuring above). This means if we need a Vue prop for validation purposes we can make the change and there isn't a API breakage.
3. It also allows us to quickly add validation by moving a Deck property to a vue prop where we can then do Validation, set requirements, etc.

One con that I've discovered, and is the only one I can see at the moment is that because we are passing HTML attributes, there is name collision with built-in HTML attributes (class, style, etc) so Mapbox has a parameter called "style" and I had to specify a map_style prop to be passed and then translated back to the correct keyword for Mapbox. Obviously these cases are limited to HTML attributes which I don't think we should expect that many collisions.

I also updated the App component as an example.