### PR TITLE
VD-24: Defaults

### DIFF
--- a/src/components/deckgl/DeckGl.vue
+++ b/src/components/deckgl/DeckGl.vue
@@ -9,6 +9,7 @@
 import { Deck } from "@deck.gl/core"
 
 import processChildren from "../utils/processChildren.js"
+import {DECKGL_SETTINGS} from '../utils/defaultSettings.js'
 
 export default {
     name: 'deckgl',
@@ -29,7 +30,7 @@ export default {
         }        
     },
     mounted() {
-        this.deck = new Deck({ 
+        this.deck = new Deck({ ...DECKGL_SETTINGS,
         ...this.$attrs, 
         ...this.$props, 
         onViewStateChange: this.moveMap,

--- a/src/components/mapbox/Mapbox.vue
+++ b/src/components/mapbox/Mapbox.vue
@@ -6,6 +6,7 @@
 <script>
     import mapboxgl from 'mapbox-gl'
     import 'mapbox-gl/dist/mapbox-gl.css'
+    import {MAPBOX_SETTINGS} from '../utils/defaultSettings.js'
 
     export default {
         name:'Mapbox',
@@ -21,12 +22,13 @@
             },
             map_style: {
                 type: String,
-                required: false
+                required: false,
+                default: MAPBOX_SETTINGS.style
             }
         },
         mounted() {
             mapboxgl.accessToken = this.accessToken
-            this.map = new mapboxgl.Map({...this.$attrs, style: this.map_style})
+            this.map = new mapboxgl.Map({...MAPBOX_SETTINGS, ...this.$attrs, style: this.map_style })
         },
         methods: {
             jumpTo(center, zoom, bearing, pitch){

--- a/tests/unit/deckgl.spec.js
+++ b/tests/unit/deckgl.spec.js
@@ -7,11 +7,12 @@ import { DeckGL } from "../../src/components/deckgl";
 let wrapper;
 
 beforeAll(() => {
-  wrapper = shallowMount(DeckGL, {
-    props:{
-      settings: DECKGL_SETTINGS
-    }
-  });
+  wrapper = shallowMount(DeckGL,{
+      attrs:{
+        canvas: null,
+    },
+  }
+    );
 });
 
 afterAll(()=>{

--- a/tests/unit/utils/processChildren.spec.js
+++ b/tests/unit/utils/processChildren.spec.js
@@ -1,7 +1,6 @@
 import { shallowMount } from "@vue/test-utils";
 
 import processChildren from "../../../src/components/utils/processChildren.js"
-import { DECKGL_SETTINGS, MAPBOX_SETTINGS } from "../../../src/components/utils/defaultSettings.js"
 import { DeckGL } from "../../../src/components/deckgl";
 import { Mapbox } from "../../../src/components/mapbox";
 
@@ -19,8 +18,8 @@ describe("processChildren", () => {
         mapboxComponentWithoutProps.name = Mapbox.name
 
         const deckComponent = shallowMount(DeckGL, {
-            props:{
-                settings: DECKGL_SETTINGS
+            attrs:{
+                canvas: null,
             },
             slots:{
                 default: mapboxComponentWithoutProps
@@ -33,10 +32,9 @@ describe("processChildren", () => {
 
     it("should not return a map with no slotted components", ()=>{
         const deckComponent = shallowMount(DeckGL,{
-            props:{
-                settings: DECKGL_SETTINGS
-            }
-        })
+        attrs:{
+            canvas: null,
+        },})
         
         const mapComponent = processChildren(deckComponent.$children)
         expect(mapComponent).toBeNull()


### PR DESCRIPTION
This builds off #12 and adds Default DeckGL/Mapbox properties. Those default settings can be overridden.

This also updates test coverage by passing an attribute of canvas=None because we are shallowMounting Deck Components which means our child components aren't rendered and we don't want Deck expecting a canvas.