### PR TITLE
Slotted Layer Components 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,40 +54,32 @@ For full explanation, [please visit the tutorial](https://loftylabs.github.io/vu
                 :bearing="0"
                 :pitch="45"
                 />
+        <GeoJsonLayer 
+        :layerData="'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'"             
+        :id="'mylayer'"
+        :opacity="0.8"
+        :stroke="false"
+        :filled="true"
+        :extruded="true"
+        :wireframe="true"
+        :fp64="true"
+        :getElevation="f => Math.sqrt(f.properties.valuePerSqm) * 10"
+        :getLineColor="[255, 255, 255]"
+        :pickable="true" />
     </DeckGL>
   </div>
 </template>
 
 <script>
-import {DeckGL, Mapbox} from '@hirelofty/vue_deckgl'
-import {GeoJsonLayer} from '@deck.gl/layers';
+import {DeckGL, Mapbox, GeoJsonLayer} from '@hirelofty/vue_deckgl'
 
 export default {
   name: 'App',
   components: {
     DeckGL,
-    Mapbox
+    Mapbox,
+    GeoJsonLayer
   }, 
-  data(){
-      return{
-          layers:[]
-      }
-  },
-  mounted(){
-        this.layers.push(new GeoJsonLayer({
-            id: 'mylayer',
-            data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json',
-            opacity: 0.8,
-            stroked: false,
-            filled: true,
-            extruded: true,
-            wireframe: true,
-            fp64: true,
-            getElevation: f => Math.sqrt(f.properties.valuePerSqm) * 10,
-            getLineColor: [255, 255, 255],
-            pickable: true,
-        }))
-  }
 }
 </script>
 

--- a/_docs/content/en/instant.md
+++ b/_docs/content/en/instant.md
@@ -14,7 +14,6 @@ menuTitle: 'Instant Example'
       <DeckGL ref="deck"
             :class="['fill-wrapper']"
             :controlMap="true"
-            :layers="layers"
             :width="'100%'"
             :height="'100%'"
             :controller="true"
@@ -22,46 +21,39 @@ menuTitle: 'Instant Example'
             :viewState="{latitude: 49.254, longitude: -123.13, zoom: 11, maxZoom: 16, pitch: 45, bearing: 0}"
             >
         <Mapbox class="fill-wrapper" 
-                :accessToken="'YOUR MAPBOX TOKEN'"                 
-                :center="[-123.13, 49.254]"
-                :zoom="11"
-                :bearing="0"
-                :pitch="45"
-                />
+          :accessToken="'YOUR MAPBOX TOKEN'"                 
+          :center="[-123.13, 49.254]"
+          :zoom="11"
+          :bearing="0"
+          :pitch="45"
+          />
+        <GeoJsonLayer 
+          :layerData="'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'"             
+          :id="'mylayer'"
+          :opacity="0.8"
+          :stroke="false"
+          :filled="true"
+          :extruded="true"
+          :wireframe="true"
+          :fp64="true"
+          :getElevation="f => Math.sqrt(f.properties.valuePerSqm) * 10"
+          :getLineColor="[255, 255, 255]"
+          :pickable="true"
+      />
     </DeckGL>
   </div>
 </template>
 
 <script>
-import {DeckGL, Mapbox} from '@hirelofty/vue_deckgl'
-import {GeoJsonLayer} from '@deck.gl/layers';
+import {DeckGL, Mapbox, GeoJsonLayer} from '@hirelofty/vue_deckgl'
 
 export default {
   name: 'App',
   components: {
     DeckGL,
-    Mapbox
+    Mapbox, 
+    GeoJsonLayer
   }, 
-  data(){
-      return{
-          layers:[]
-      }
-  },
-  mounted(){
-        this.layers.push(new GeoJsonLayer({
-            id: 'mylayer',
-            data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json',
-            opacity: 0.8,
-            stroked: false,
-            filled: true,
-            extruded: true,
-            wireframe: true,
-            fp64: true,
-            getElevation: f => Math.sqrt(f.properties.valuePerSqm) * 10,
-            getLineColor: [255, 255, 255],
-            pickable: true,
-        }))
-  }
 }
 </script>
 

--- a/_docs/content/en/tutorial/layers.md
+++ b/_docs/content/en/tutorial/layers.md
@@ -10,10 +10,11 @@ menuTitle: 'Adding Data With Layers'
 
 DeckGL accepts data through the use of [many types of different layers](https://deck.gl/docs/api-reference/layers). 
 
-To provide data to DeckGL, we simply create a Layer using the DeckGL Core Library and pass it to the `:layers` prop on the DeckGL Component. 
-  - Data passed to the layer could be a URL to the data or data that you fetch yourself via fetch/axois.
+Because we love Declarative Templating so much, we simply slot a Layer Component inside of Vue DeckGL using the provided Vue DeckGL Layers. While this ultimately is just a thin abstraction for declarative templating, we hope to eventually add "nice-to-haves" to make working with Layers a little easier.
+ 
 
 In this example, we will be using GeoJSON data provided via this URL: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'
+  - Data passed to the layer component could be a URL to the data or data that you fetch yourself via fetch/axois.
 
 ```
 <template>
@@ -21,7 +22,6 @@ In this example, we will be using GeoJSON data provided via this URL: 'https://r
       <DeckGL ref="deck"
             :class="['fill-wrapper']"
             :controlMap="true"
-            :layers="layers"
             :width="'100%'"
             :height="'100%'"
             :controller="true"
@@ -34,40 +34,33 @@ In this example, we will be using GeoJSON data provided via this URL: 'https://r
                 :zoom="11"
                 :bearing="0"
                 :pitch="45"/>
+        <GeoJsonLayer 
+          :layerData="'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json'"             
+          :id="'mylayer'"
+          :opacity="0.8"
+          :stroke="false"
+          :filled="true"
+          :extruded="true"
+          :wireframe="true"
+          :fp64="true"
+          :getElevation="f => Math.sqrt(f.properties.valuePerSqm) * 10"
+          :getLineColor="[255, 255, 255]"
+          :pickable="true"
+      />
     </DeckGL>
   </div>
 </template>
 
 <script>
-import {DeckGL, Mapbox} from '@hirelofty/vue_deckgl'
-import {GeoJsonLayer} from '@deck.gl/layers';
+import {DeckGL, Mapbox, GeoJsonLayer} from '@hirelofty/vue_deckgl'
 
 export default {
   name: 'App',
   components: {
     DeckGL,
-    Mapbox
+    Mapbox,
+    GeoJsonLayer
   }, 
-  data(){
-      return{
-          layers:[]
-      }
-  },
-  mounted(){
-        this.layers.push(new GeoJsonLayer({
-            id: 'mylayer',
-            data: 'https://raw.githubusercontent.com/uber-common/deck.gl-data/master/examples/geojson/vancouver-blocks.json',
-            opacity: 0.8,
-            stroked: false,
-            filled: true,
-            extruded: true,
-            wireframe: true,
-            fp64: true,
-            getElevation: f => Math.sqrt(f.properties.valuePerSqm) * 10,
-            getLineColor: [255, 255, 255],
-            pickable: true,
-        }))
-  }
 }
 </script>
 
@@ -81,17 +74,31 @@ Notes about the implementation above
 - We provide new GeoJsonLayer with a url to the data.
 - Because this data is in Vancouver, we set the viewState of DeckGL and Mapbox to default to Vancouver so we can see it.
 
-#### Future Implementation of Layers
+#### Are we not currently providing a layer you want to use? Create it and submit a PR! It's easy!
 
-Because we love Declarative Templating so much, our eventual goal is to build small Component wrappers around Layers so that the API is providing Layers via Slot rather than props. These also will include "nice to haves" that make Layers easier to use.
+To do this, all you need to do is create a layer that utilizes the BaseLayerMixin. This mixin is how Vue DeckGL knows that a slotted component passed was a layer type. Here's a quick example of implementing a GeoJsonLayer
 
-An example being...
 ```
 <template>
-    <DeckGL>
-        <Mapbox />
-        <GeoJsonLayer :data='DATA' />
-        <ScatterPlotLayer :data='DATA' />
-    </DeckGL>
+  <div></div>
 </template>
+
+<script>
+import {GeoJsonLayer} from '@deck.gl/layers';
+
+import BaseLayerMixin from './BaseLayerMixin'
+
+export default {
+    name: 'GeoJsonLayer',
+    mixins:[BaseLayerMixin],
+    created(){
+        this.layer = new GeoJsonLayer({
+            ...this.$attrs,
+            data: this.layerData,
+        })
+    },
+}
+</script>
 ```
+
+That's it! Now mileage may vary if you are attempting to implement a more complicated layer, but the key piece is that you simply add the BaseLayerMixin. 

--- a/_docs/content/en/tutorial/layers.md
+++ b/_docs/content/en/tutorial/layers.md
@@ -95,5 +95,6 @@ export default {
 }
 </script>
 ```
-
 That's it! Now mileage may vary if you are attempting to implement a more complicated layer, but the key piece is that you simply add the BaseLayerMixin. 
+
+Note the `render: () => null` method. Because we are creating a Vue component that does not render any HTML, but instead works with Deck.gl to display data, we can override the Vue render method to return null here, to do nothing. This allows us to avoid having to include an empty template in our code.

--- a/_docs/content/en/tutorial/layers.md
+++ b/_docs/content/en/tutorial/layers.md
@@ -79,15 +79,9 @@ Notes about the implementation above
 To do this, all you need to do is create a layer that utilizes the BaseLayerMixin. This mixin is how Vue DeckGL knows that a slotted component passed was a layer type. Here's a quick example of implementing a GeoJsonLayer
 
 ```
-<template>
-  <div></div>
-</template>
-
 <script>
 import {GeoJsonLayer} from '@deck.gl/layers';
-
 import BaseLayerMixin from './BaseLayerMixin'
-
 export default {
     name: 'GeoJsonLayer',
     mixins:[BaseLayerMixin],
@@ -97,6 +91,7 @@ export default {
             data: this.layerData,
         })
     },
+    render: () => null
 }
 </script>
 ```

--- a/_docs/content/en/tutorial/settings.md
+++ b/_docs/content/en/tutorial/settings.md
@@ -39,7 +39,6 @@ Some of these props are more important than others. Some will have minor explana
 ### DeckGL
 - `:class=""` - Need some CSS to visualize your component.
 - `:controlMap="true/false"` - tells the Vue_DeckGL Component it needs to manually interact with the slotted Mapbox component (not a native DeckGL Prop)
-- `:layers=[]` - where data will be provided. Minor explanation later. 
 - `:controller="true/false"` - Allows for DeckGL manual interactivity. Minor explanation later. 
 - `:viewState="{viewState}"` - Initial viewState object. Minor explanation later. 
 

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -25,6 +25,20 @@
                 :bearing="mapboxSettings.bearing"
                 :pitch="mapboxSettings.pitch"
                 />
+                <GeoJsonLayer 
+                :layerData="data_url"             
+                :id="'mylayer'"
+                :opacity="0.8"
+                :stroke="false"
+                :filled="true"
+                :extruded="true"
+                :wireframe="true"
+                :fp64="true"
+                :getElevation="f => Math.sqrt(f.properties.valuePerSqm) * 10"
+                :getFillColor="f => colorScale(f.properties.growth)"
+                :getLineColor="[255, 255, 255]"
+                :pickable="true"
+            />
         </DeckGl>
         <h1 v-if="!hasDeckLoaded">Loading...</h1>
         <div style="position:absolute;">
@@ -38,13 +52,13 @@
 <script>
     import DeckGl from '../src/components/deckgl'
     import Mapbox from '../src/components/mapbox'
+    import GeoJsonLayer from '../src/components/layers/GeoJsonLayer'
     import { MAPBOX_SETTINGS, DECKGL_SETTINGS, DATA_URL} from './exampleSettings'
-    import {GeoJsonLayer} from '@deck.gl/layers';
     import MAPBOX_TOKEN from '../env.js'
     import {getTooltip, colorScale} from './exampleUtils'
 
     export default {
-        components: { Mapbox, DeckGl },
+        components: { Mapbox, DeckGl, GeoJsonLayer },
         name: 'Example',
         data() {
             return {
@@ -52,7 +66,9 @@
                 mapboxSettings: MAPBOX_SETTINGS,
                 deckglSettings: DECKGL_SETTINGS,
                 layers:[ ],
-                hasDeckLoaded: false
+                hasDeckLoaded: false,
+                data_url: '',
+                colorScale: colorScale
             }
         },
         methods: {
@@ -67,21 +83,8 @@
                 console.log(this.$refs.deck.pickObjects(100, 100, 1, 1, null))
             }
         },
-        mounted(){            
-            this.layers.push(new GeoJsonLayer({
-                        id: 'mylayer',
-                        data: DATA_URL,
-                        opacity: 0.8,
-                        stroked: false,
-                        filled: true,
-                        extruded: true,
-                        wireframe: true,
-                        fp64: true,
-                        getElevation: f => Math.sqrt(f.properties.valuePerSqm) * 10,
-                        getFillColor: f => colorScale(f.properties.growth),
-                        getLineColor: [255, 255, 255],
-                        pickable: true,
-        }))
+        created(){            
+            this.data_url = DATA_URL
         }
     }
 </script>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "author": "hirelofty.com",
   "scripts": {
-    "serve": "vue serve",
+    "serve": "vue serve dev/App.vue",
     "test:unit": "vue-cli-service test:unit",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hirelofty/vue_deckgl",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "author": "hirelofty.com",
   "scripts": {

--- a/src/components/deckgl/DeckGl.vue
+++ b/src/components/deckgl/DeckGl.vue
@@ -18,18 +18,15 @@ export default {
             deck: {},
             map: {},
             hasHandlers: false,
-            afterRenderCounter: 0 
+            afterRenderCounter: 0,
+            layers: []
         }
     },
     props: {
         controlMap: {
             type: Boolean,
             default: false
-        },
-        layers: {
-            type: Array,
-            required: false
-        }        
+        },  
     },
     mounted() {
         this.deck = new Deck({ ...DECKGL_SETTINGS,
@@ -38,7 +35,13 @@ export default {
             onAfterRender: this.setupHandlers
             })
 
-        this.map = processChildren(this.$children)
+        const processedChildren = processChildren(this.$children)
+        this.map = processedChildren.map
+
+        processedChildren.layers.forEach(layer => {
+            this.layers.push(layer.getLayer())
+        })
+
         window.addEventListener('resize', this.onWindowResizeHandler)
         
     },

--- a/src/components/layers/BaseLayerMixin.js
+++ b/src/components/layers/BaseLayerMixin.js
@@ -1,0 +1,21 @@
+const BaseLayerMixin = {
+    data(){
+        return{
+            layer: {},
+            baseLayerAttached: true
+        }
+    },
+    props:{
+        layerData: {
+            type: String,
+            required: true
+        },
+    },
+    methods: {
+        getLayer(){
+            return this.layer
+        }
+    }
+}
+
+export default BaseLayerMixin

--- a/src/components/layers/BaseLayerMixin.js
+++ b/src/components/layers/BaseLayerMixin.js
@@ -2,7 +2,7 @@ const BaseLayerMixin = {
     data(){
         return{
             layer: {},
-            baseLayerAttached: true
+            baseLayerImplemented: true
         }
     },
     props:{

--- a/src/components/layers/GeoJsonLayer.vue
+++ b/src/components/layers/GeoJsonLayer.vue
@@ -1,0 +1,24 @@
+<template>
+  <div></div>
+</template>
+
+<script>
+import {GeoJsonLayer} from '@deck.gl/layers';
+
+import BaseLayerMixin from './BaseLayerMixin'
+
+export default {
+    name: 'GeoJsonLayer',
+    mixins:[BaseLayerMixin],
+    created(){
+        this.layer = new GeoJsonLayer({
+            ...this.$attrs,
+            data: this.layerData,
+        })
+    },
+}
+</script>
+
+<style>
+
+</style>

--- a/src/components/layers/GeoJsonLayer.vue
+++ b/src/components/layers/GeoJsonLayer.vue
@@ -1,7 +1,3 @@
-<template>
-  <div></div>
-</template>
-
 <script>
 import {GeoJsonLayer} from '@deck.gl/layers';
 
@@ -16,5 +12,6 @@ export default {
             data: this.layerData,
         })
     },
+    render: () => null
 }
 </script>

--- a/src/components/layers/GeoJsonLayer.vue
+++ b/src/components/layers/GeoJsonLayer.vue
@@ -18,7 +18,3 @@ export default {
     },
 }
 </script>
-
-<style>
-
-</style>

--- a/src/components/layers/index.js
+++ b/src/components/layers/index.js
@@ -1,0 +1,5 @@
+
+import BaseLayerMixin from './BaseLayerMixin'
+import GeoJsonlayer from './GeoJsonlayer'
+
+export { BaseLayerMixin, GeoJsonlayer } 

--- a/src/components/utils/processChildren.js
+++ b/src/components/utils/processChildren.js
@@ -1,5 +1,6 @@
 export default (children) => {
     let map = null
+    let layers = []
 
     if(children === undefined){
         return map
@@ -10,6 +11,9 @@ export default (children) => {
         if(child.$options._componentTag === 'Mapbox'){
             map = child
         }
+        else if(child.baseLayerAttached){
+            layers.push(child)
+        }
     });
-    return map
+    return {map, layers}
 }

--- a/src/components/utils/processChildren.js
+++ b/src/components/utils/processChildren.js
@@ -11,7 +11,7 @@ export default (children) => {
         if(child.$options._componentTag === 'Mapbox'){
             map = child
         }
-        else if(child.baseLayerAttached){
+        else if(child.baseLayerImplemented){
             layers.push(child)
         }
     });

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 
 import DeckGL from './components/deckgl'
 import Mapbox from './components/mapbox'
+import {BaseLayerMixin, GeoJsonLayer} from './components/layers'
 
 export default DeckGL
-export {DeckGL, Mapbox}
+export {DeckGL, Mapbox, BaseLayerMixin, GeoJsonLayer}


### PR DESCRIPTION
This PR references #24 and #25 

This adds the initial BaseLayer mixin that we can use to create Layer Components. An initial GeoJsonLayer component has been created. 

processChildren has also been updated to account for if a BaseLayer is detected along with the logic to add layers.

The documentation/version number has also been updated. 