### PR TITLE
VD-22: Tooltip Documentation

### DIFF
--- a/_docs/content/en/tutorial/interactivity.md
+++ b/_docs/content/en/tutorial/interactivity.md
@@ -14,6 +14,102 @@ Interactivity comes in a couple different forms with DeckGL
 
 - Controll the Viewport: `:controller="true" :controlMap="true" ` ship by default, but these properties enable DeckGL/Mapbox to respond to viewState changes via mouse drag, scroll,etc.
 
+
+### Interacting with onHover and adding Tooltips
+
+With DeckGL we can hook into either DeckGL's getTooltip event or a Layer's individual onHover event. Both callbacks look effectively the same. 
+- DeckGL: `:getTooltip="CALLBACK`
+- Layer: `:onHover="CALLBACK"`
+
+DeckGL provides two options as you may want to handle a individual type of Layers onHover differently. Like rendering different tooltips.
+
+A tooltip in this case is just a HTML element that we render in our templates using a `v-if`.
+
+```
+<template> 
+  <DeckGL
+  :getTooltip="deckToolTipCallback
+  >
+  </DeckGL>
+...
+  <div id="example-deck-tooltip" v-if="deckTooltipHovered" :style="hoverPosition">
+      <p>valuePerSqm: {{deckHoveredData.valuePerSqm}}</p>
+      <p>Growth: {{deckHoveredData.growth}}</p>
+  </div>
+...
+</template>
+
+<script>
+data:{
+  return {
+    ...
+    deckTooltipHovered: false,
+    deckHoveredData: {x:0, y:0, valuePerSqm: 0, growth:0}
+  }
+},
+computed: {
+      hoverPosition: function () {
+        return {
+            'position': 'absolute',
+            'left': (this.deckHoveredData.x + 30) + 'px',
+            'top': (this.deckHoveredData.y + + 30) + 'px'
+        }
+    }
+},
+methods: {
+  deckTooltipCallback({x,y, picked, object}){
+      if(!(picked)){
+          this.deckTooltipHovered = false
+          return 
+      }
+      
+      this.deckTooltipHovered = true
+      this.deckHoveredData.x = x
+      this.deckHoveredData.y = y
+      this.deckHoveredData.valuePerSqm = object.properties.valuePerSqm
+      this.deckHoveredData.growth = object.properties.growth
+  },
+}
+</script>
+<style scoped>
+    #example-deck-tooltip{
+        position:absolute;
+        background-color:purple;
+        width:10%;
+        height:10%;
+    }
+</style>
+```
+
+We implement a tooltip by doing the following
+- Create a HTML element that will hold data that we conditionally render and provide style to.
+- Create data for Vue to be reactive on. 
+- Generate a computed style property that will render the Tooltip in the location of the values that come back from the Hover event.
+- Create a callback for getTooltip that destructures that data provided. 
+- Create some default styling for a tooltip that won't change.
+
+To implement this at a Layer level, we would only need to change the following:
+
+```
+<template> 
+  <DeckGL
+  >
+  ...
+  <GeoJsonLayer 
+    onHover="deckTooltipCallback"
+  />
+  </DeckGL>
+...
+  <div id="example-deck-tooltip" v-if="deckTooltipHovered" :style="hoverPosition">
+      <p>valuePerSqm: {{deckHoveredData.valuePerSqm}}</p>
+      <p>Growth: {{deckHoveredData.growth}}</p>
+  </div>
+...
+</template>
+```
+
+
+
 #### Advanced: Picking Objects
 
 We have also exposed the picking engine of DeckGL through a public facing API which you can access by a `ref` on the DeckGL component. 

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -12,6 +12,8 @@
             :useDevicePixels="false"
             :viewState="deckglSettings.viewState"
             @initialRender="()=>{hasDeckLoaded = true}"
+            :getTooltip="deckTooltipCallback"
+            
             >
                 <Mapbox
                 :class="['fill-wrapper']"
@@ -38,6 +40,7 @@
                 :getFillColor="f => colorScale(f.properties.growth)"
                 :getLineColor="[255, 255, 255]"
                 :pickable="true"
+                :onHover="deckTooltipCallback"
             />
         </DeckGl>
         <h1 v-if="!hasDeckLoaded">Loading...</h1>
@@ -45,6 +48,10 @@
             <button  @click="testSinglePick">Test Deck Single Pick object</button>
             <button  @click="testMultiPick">Test Deck Multi Pick object</button>
             <button  @click="testObjectsPick">Test Deck Objects Pick object</button>
+        </div>
+        <div id="example-deck-tooltip" v-if="deckTooltipHovered" :style="hoverPosition">
+            <p>valuePerSqm: {{deckHoveredData.valuePerSqm}}</p>
+            <p>Growth: {{deckHoveredData.growth}}</p>
         </div>
     </div>
 </template>
@@ -68,11 +75,34 @@
                 layers:[ ],
                 hasDeckLoaded: false,
                 data_url: '',
-                colorScale: colorScale
+                colorScale: colorScale,
+                deckTooltipHovered: false,
+                deckHoveredData: {x:0, y:0, valuePerSqm: 0, growth:0}
+            }
+        },
+        computed: {
+              hoverPosition: function () {
+                return {
+                    'position': 'absolute',
+                    'left': (this.deckHoveredData.x + 30) + 'px',
+                    'top': (this.deckHoveredData.y + + 30) + 'px'
+                }
             }
         },
         methods: {
            getTooltip,
+            deckTooltipCallback({x,y, picked, object}){
+                if(!(picked)){
+                    this.deckTooltipHovered = false
+                    return 
+                }
+                
+                this.deckTooltipHovered = true
+                this.deckHoveredData.x = x
+                this.deckHoveredData.y = y
+                this.deckHoveredData.valuePerSqm = object.properties.valuePerSqm
+                this.deckHoveredData.growth = object.properties.growth
+            },
             testSinglePick(){
                 console.log(this.$refs.deck.pickObject(100, 100, 0, null, false))
             },
@@ -96,5 +126,11 @@
         left: 0;
         width: 100%;
         height: 100%;
+    }
+    #example-deck-tooltip{
+        position:absolute;
+        background-color:purple;
+        width:10%;
+        height:10%;
     }
 </style>


### PR DESCRIPTION
Updates the default app to have Tooltip for testing and also updates the documentation and provides an example on how to hook into DeckGL/Layer event bindings to create a tooltip